### PR TITLE
[Feat] - 회원 영구정지/탈퇴/회원신고 최대3번만

### DIFF
--- a/src/main/java/com/back/domain/auction/auction/service/AuctionService.java
+++ b/src/main/java/com/back/domain/auction/auction/service/AuctionService.java
@@ -19,6 +19,7 @@ import com.back.domain.category.category.repository.CategoryRepository;
 import com.back.domain.image.image.entity.Image;
 import com.back.domain.image.image.repository.ImageRepository;
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.enums.MemberStatus;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.exception.ServiceException;
@@ -55,7 +56,7 @@ public class AuctionService {
         log.debug("경매 생성 시작 - 판매자 ID: {}, 물품명: {}, 시작가: {}원", sellerId, request.getName(), request.getStartPrice());
 
         // 정지된 회원의 글쓰기 방지
-        if(!memberService.findById(sellerId).get().getActive()) {
+        if(memberService.findById(sellerId).get().getStatus() == MemberStatus.SUSPENDED) {
             log.warn("경매 생성 실패 - 정지된 회원: 사용자 ID: {}", sellerId);
             throw new ServiceException("403-3", "정지된 회원은 해당 기능을 사용할 수 없습니다.");
         }

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -209,8 +209,9 @@ public class MemberController {
     @PatchMapping("/{userId}/credit")
     public RsData<Void> decrease(@PathVariable int userId) {
         Member member = memberService.findById(userId).get();
+        Member reporter = rq.getActor();
 
-        memberService.decreaseByNofiy(member);
+        memberService.decreaseByNofiy(member, reporter);
 
         return new RsData<>(
                 "200-1",

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -87,10 +87,7 @@ public class MemberController {
         Member member = memberService.findByUsername(reqBody.username())
                 .orElseThrow(() -> new ServiceException("401-1", "존재하지 않는 아이디입니다."));
 
-        memberService.checkPassword(
-                member,
-                reqBody.password()
-        );
+        memberService.login(member, reqBody.password());
 
         String accessToken = memberService.genAccessToken(member);
 
@@ -132,12 +129,30 @@ public class MemberController {
         return new MemberWithUsernameDto(actor);
     }
 
+
+    @DeleteMapping("/me")
+    @Transactional(readOnly = true)
+    @Operation(summary = "회원 탈퇴")
+    public RsData<Void> withdraw() {
+        Member actor = rq.getActorFromDb();
+        rq.deleteCookie("apiKey");
+        rq.deleteCookie("accessToken");
+        memberService.withdraw(actor);
+
+        return new RsData<>(
+                "200-1",
+                "탙퇴가 정상적으로 처리되었습니다."
+        );
+    }
+
+
     record MemberNameModifyReqBody(
             @NotBlank
             @Size(min = 2, max = 30)
             String nickname
     ) {
     }
+
 
     @PatchMapping("/me/nickname")
     @Transactional

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.back.domain.member.member.entity;
 
 import com.back.domain.member.member.enums.Role;
+import com.back.domain.member.member.enums.MemberStatus;
 import com.back.domain.member.reputation.entity.Reputation;
 import com.back.domain.member.reputation.entity.ReputationEvent;
 import com.back.domain.member.review.entity.Review;
@@ -33,7 +34,9 @@ public class Member extends BaseEntity {
     @Column(unique = true)
     private String nickname;
 
-    private boolean active;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberStatus status;
 
     @Column(unique = true)
     private String apiKey;
@@ -49,13 +52,15 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<Review> reviews;
 
-    @Setter
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
 
     @Column(nullable = true)
     private LocalDateTime suspendAt;  // 정지 시각
+
+    @Column(nullable = true)
+    private LocalDateTime deleteAt;  // 영구 정지 시각
 
 
     public Member(int id, String username, String name, Role role) {
@@ -73,10 +78,18 @@ public class Member extends BaseEntity {
         this.username = username;
         this.password = password;
         this.nickname = nickname;
-        this.active = true;
+        this.status = MemberStatus.ACTIVE;
         this.apiKey = UUID.randomUUID().toString();
         this.profileImgUrl = profileImgUrl;
         setRole(Role.USER);
+    }
+
+    public MemberStatus getActive() {
+        return this.status;
+    }
+
+    public String getNickname() {
+        return this.status == MemberStatus.WITHDRAWN ? "탈퇴한 회원" : this.nickname;
     }
 
 
@@ -86,6 +99,7 @@ public class Member extends BaseEntity {
     }
 
 
+    // 수정 관련
     public void modifyApiKey(String apiKey) {
         this.apiKey = apiKey;
     }
@@ -104,21 +118,33 @@ public class Member extends BaseEntity {
     }
 
 
+    // 계정 활성화 관련
+    // 계정 정지
     public void suspend() {
-        this.active = false;
+        this.status = MemberStatus.SUSPENDED;
         this.suspendAt = LocalDateTime.now();
     }
 
+    // 계정 재활성화
     public void release() {
-        this.active = true;
+        this.status = MemberStatus.ACTIVE;
         this.suspendAt = null;
     }
 
-    public boolean getActive() {
-        return active;
+    // 계정 영구 정지
+    public void banned() {
+        this.status = MemberStatus.BANNED;
+        this.deleteAt = LocalDateTime.now();
+    }
+
+    // 계정 탈퇴
+    public void withdraw() {
+        this.status = MemberStatus.WITHDRAWN;
+        this.deleteAt = LocalDateTime.now();
     }
 
 
+    // 계정 인가 관련
     public boolean isAdmin() {
         if (this.role == Role.ADMIN) return true;
 

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -46,8 +46,11 @@ public class Member extends BaseEntity {
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
     private Reputation reputation;
 
-    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
-    private List<ReputationEvent> reputationEvents;
+    @OneToMany(mappedBy = "target", fetch = FetchType.LAZY)
+    private List<ReputationEvent> targetEvents;
+
+    @OneToMany(mappedBy = "reporter", fetch = FetchType.LAZY)
+    private List<ReputationEvent> reporterEvents;
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<Review> reviews;

--- a/src/main/java/com/back/domain/member/member/enums/MemberStatus.java
+++ b/src/main/java/com/back/domain/member/member/enums/MemberStatus.java
@@ -1,0 +1,8 @@
+package com.back.domain.member.member.enums;
+
+public enum MemberStatus {
+    ACTIVE,        // 정상
+    SUSPENDED,     // 일시 정지
+    WITHDRAWN,     // 회원 탈퇴
+    BANNED         // 영구 정지
+}

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.back.domain.member.member.service;
 import com.back.domain.auction.auction.entity.Auction;
 import com.back.domain.auction.auction.repository.AuctionRepository;
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.enums.MemberStatus;
 import com.back.domain.member.review.entity.Review;
 import com.back.domain.member.review.repository.ReviewRepository;
 import com.back.domain.member.reputation.entity.Reputation;
@@ -15,7 +16,8 @@ import com.back.domain.member.reputation.repository.ReputationEventRepository;
 import com.back.domain.member.reputation.repository.ReputationRepository;
 import com.back.global.exception.ServiceException;
 import com.back.global.rsData.RsData;
-import com.back.standard.util.Ut;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -86,6 +88,29 @@ public class MemberService {
         member.modify(nickname, profileImgUrl);
     }
 
+    // 로그인
+    public void login(Member member, String password) {
+        if (member.getStatus() == MemberStatus.BANNED)
+            throw new ServiceException("403-3", "계정이 영구 정지되었습니다. 관리자에게 문의해주세요.");
+
+        if (member.getStatus() == MemberStatus.WITHDRAWN)
+            throw new ServiceException("403-4", "탈퇴한 계정입니다.");
+
+        checkPassword(member, password);
+    }
+
+    // 회원 탈퇴
+    public void withdraw(Member actor) {
+        Member member = memberRepository.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException("404-1", "회원 없음"));
+
+        if (member.getStatus() == MemberStatus.WITHDRAWN) {
+            throw new ServiceException("400-1", "이미 탈퇴한 회원입니다.");
+        }
+
+        actor.withdraw();
+    }
+
 
     public Optional<Member> findByUsername(String username) {
         return memberRepository.findByUsername(username);
@@ -145,8 +170,8 @@ public class MemberService {
 
         Reputation reputation = reputationRepository.findById(userId).get();
 
-        // 이미 정지 상태면 신고 누적 X
-        if (!member.getActive()) {
+        // 이미 정지/탈퇴/영구정지 상태면 신고 누적 X
+        if (member.getStatus() == MemberStatus.SUSPENDED || member.getStatus() == MemberStatus.BANNED || member.getStatus() == MemberStatus.WITHDRAWN) {
             return;
         }
 
@@ -154,14 +179,19 @@ public class MemberService {
         reputation.increaseNotify();
 
         // 신고 10회 누적 시마다 신용도 감소
-        if(reputation.getNotifyCount() % 10 == 0) {
+        if (reputation.getNotifyCount() % 10 == 0) {
             reputation.decrease();
         }
 
-        // 신고 누적 100회 -> 일주일간 정지 회원
-        if(reputation.getNotifyCount() >= 100) {
+        // 신고 누적 100회 -> 일주일간 정지
+        if (reputation.getNotifyCount() >= 100) {
             member.suspend();
             reputation.setNotifyCount(0);
+        }
+
+        // 신고 누적 10000회 이상 -> 영구 정지
+        if (reputation.getTotalNotifyCount() >= 10000) {
+            member.banned();
         }
     }
 
@@ -205,7 +235,7 @@ public class MemberService {
     // 리뷰 생성
     @Transactional
     public Review createReview(int star, String msg, Member member, int reviewerId) {
-        if(!findById(reviewerId).get().getActive()) {
+        if(findById(reviewerId).get().getStatus() == MemberStatus.SUSPENDED) {
             throw new ServiceException("403-3", "정지된 회원은 해당 기능을 사용할 수 없습니다.");
         }
         Review review = new Review(member, star, msg, reviewerId);

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -163,16 +163,24 @@ public class MemberService {
 
     // 신고에 의한 신용도 감소
     @Transactional
-    public void decreaseByNofiy(Member member) {
-        int userId = member.getId();
-        ReputationEvent event = new ReputationEvent(member, EventType.NOTIFY, RefType.DEAL);
+    public void decreaseByNofiy(Member member, Member reporter) {
+        int targetId = member.getId();
+        int reporterId = reporter.getId();
+        int count = eventRepository.countByTargetIdAndReporterId(targetId, reporterId);
+
+        // A 회원 대상 B 회원의 최대 신고 횟수 3
+        if (count >= 3) {
+            throw new ServiceException("403-1", "해당 회원에 대한 신고 횟수를 초과했습니다.");
+        }
+
+        ReputationEvent event = new ReputationEvent(member, EventType.NOTIFY, RefType.DEAL, reporter);
         eventRepository.save(event);
 
-        Reputation reputation = reputationRepository.findById(userId).get();
+        Reputation reputation = reputationRepository.findById(targetId).get();
 
         // 이미 정지/탈퇴/영구정지 상태면 신고 누적 X
         if (member.getStatus() == MemberStatus.SUSPENDED || member.getStatus() == MemberStatus.BANNED || member.getStatus() == MemberStatus.WITHDRAWN) {
-            return;
+            throw new ServiceException("400-2", "해당 회원은 정지된 회원입니다.");
         }
 
         // 신고 누적
@@ -210,7 +218,7 @@ public class MemberService {
             reputation.decrease();
             double after = reputation.getScore();
 
-            ReputationEvent event = new ReputationEvent(seller, EventType.CANCEL, RefType.AUCTION, auctionId, Math.abs(before - after));
+            ReputationEvent event = new ReputationEvent(seller, EventType.CANCEL, RefType.AUCTION, auctionId, Math.abs(before - after), null);
             eventRepository.save(event);
         }
     }
@@ -227,7 +235,7 @@ public class MemberService {
         reputation.increase();
         double after = reputation.getScore();
 
-        ReputationEvent event = new ReputationEvent(seller, EventType.CANCEL, RefType.AUCTION, dealId, Math.abs(before - after));
+        ReputationEvent event = new ReputationEvent(seller, EventType.CANCEL, RefType.AUCTION, dealId, Math.abs(before - after), null);
         eventRepository.save(event);
     }
 

--- a/src/main/java/com/back/domain/member/reputation/entity/ReputationEvent.java
+++ b/src/main/java/com/back/domain/member/reputation/entity/ReputationEvent.java
@@ -14,8 +14,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "reputation_events")
 public class ReputationEvent extends BaseEntity {
     @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @JoinColumn(name = "target_id")
+    private Member target;
 
     @Enumerated(EnumType.STRING)
     private EventType eventType;
@@ -25,17 +25,22 @@ public class ReputationEvent extends BaseEntity {
 
     private int refId;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = true)
+    private Member reporter;
+
     private double delta;
 
-    public ReputationEvent(Member member, EventType eventType, RefType refType) {
-        this(member, eventType, refType, 0, 0);
+    public ReputationEvent(Member target, EventType eventType, RefType refType, Member reporter) {
+        this(target, eventType, refType, 0, 0, reporter);
     }
 
-    public ReputationEvent(Member member, EventType eventType, RefType refType, int refId, double delta) {
-        this.member = member;
+    public ReputationEvent(Member target, EventType eventType, RefType refType, int refId, double delta, Member reporter) {
+        this.target = target;
         this.eventType = eventType;
         this.refType = refType;
         this.refId = refId;
         this.delta = delta;
+        this.reporter = reporter;
     }
 }

--- a/src/main/java/com/back/domain/member/reputation/repository/ReputationEventRepository.java
+++ b/src/main/java/com/back/domain/member/reputation/repository/ReputationEventRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ReputationEventRepository extends JpaRepository<ReputationEvent, Integer> {
+    int countByTargetIdAndReporterId(int targetId, int reporterId);
 }

--- a/src/main/java/com/back/domain/post/post/service/PostService.java
+++ b/src/main/java/com/back/domain/post/post/service/PostService.java
@@ -6,7 +6,7 @@ import com.back.domain.category.category.repository.CategoryRepository;
 import com.back.domain.image.image.entity.Image;
 import com.back.domain.image.image.repository.ImageRepository;
 import com.back.domain.member.member.entity.Member;
-import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.member.member.enums.MemberStatus;
 import com.back.domain.member.member.service.MemberService;
 import com.back.domain.post.post.dto.*;
 import com.back.domain.post.post.entity.Post;
@@ -34,7 +34,7 @@ public class PostService {
     @Transactional
     public int create(Member actor, PostCreateRequest req) {
         // 정지된 회원의 글쓰기 방지
-        if(!memberService.findById(actor.getId()).get().getActive()) {
+        if(memberService.findById(actor.getId()).get().getStatus() == MemberStatus.SUSPENDED) {
             throw new ServiceException("403-3", "정지된 회원은 해당 기능을 사용할 수 없습니다.");
         }
 
@@ -77,7 +77,7 @@ public class PostService {
             throw new ServiceException("403-1", "자신의 글만 수정할 수 있습니다.");
         }
 
-        if (!actor.getActive()) {
+        if(memberService.findById(actor.getId()).get().getStatus() == MemberStatus.SUSPENDED) {
             throw new ServiceException("403-3", "정지된 회원은 해당 기능을 사용할 수 없습니다.");
         }
 

--- a/src/main/java/com/back/global/initData/BaseInitData.java
+++ b/src/main/java/com/back/global/initData/BaseInitData.java
@@ -9,6 +9,7 @@ import com.back.domain.bid.bid.service.BidService;
 import com.back.domain.category.category.entity.Category;
 import com.back.domain.category.category.repository.CategoryRepository;
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.enums.MemberStatus;
 import com.back.domain.member.member.service.MemberService;
 import com.back.domain.member.review.entity.Review;
 import com.back.domain.member.review.repository.ReviewRepository;
@@ -23,8 +24,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.transaction.annotation.Transactional;
-import com.back.domain.post.post.entity.Post;
-import com.back.domain.post.post.entity.PostStatus;
 import com.back.domain.post.post.repository.PostRepository;
 
 import java.time.LocalDateTime;
@@ -75,9 +74,18 @@ public class BaseInitData {
         Member memberUser3 = memberService.join("user3", "1234", "유저3", null);
         if (AppConfig.isNotProd()) memberUser3.modifyApiKey(memberUser3.getUsername());
 
+        // 정지 회원
         Member memberUser4 = memberService.join("user4", "1234", "유저4", null);
         if (AppConfig.isNotProd()) memberUser4.modifyApiKey(memberUser4.getUsername());
+        memberUser4.setStatus(MemberStatus.SUSPENDED);
         memberUser4.setSuspendAt(LocalDateTime.now().minusDays(3));
+
+        // 영구 정지 회원
+        Member memberUser5 = memberService.join("user5", "1234", "유저5", null);
+        if (AppConfig.isNotProd()) memberUser5.modifyApiKey(memberUser5.getUsername());
+        memberUser5.setStatus(MemberStatus.BANNED);
+        memberUser5.setDeleteAt(LocalDateTime.now().minusDays(3));
+
 
         log.info("테스트 회원 생성 완료 - 총 6명");
     }

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -1,7 +1,7 @@
 package com.back.global.security;
 
 import com.back.domain.member.member.entity.Member;
-import com.back.domain.member.member.enums.Role;
+import com.back.domain.member.member.enums.MemberStatus;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.exception.ServiceException;
 import com.back.global.rq.Rq;
@@ -115,7 +115,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
                 String name = (String) payload.get("name");
                 String role = (String) payload.get("role");
 
-                member = new Member(id, username, name, Role.from(role));
+                member = memberService.findById(id).get();
 
                 isAccessTokenValid = true;
             }
@@ -136,6 +136,16 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
             // 액세스 토큰을 쿠키와 헤더에 저장
             rq.setCookie("accessToken", actorAccessToken);
             rq.setHeader("Authorization", actorAccessToken);
+        }
+
+        // 영구 정지 회원 JWT 차단
+        if (member.getStatus() == MemberStatus.BANNED) {
+            throw new ServiceException("403-4", "계정이 영구 정지되었습니다. 관리자에게 문의해주세요.");
+        }
+
+        // 탈퇴 회원 JWT 차단
+        if (member.getStatus() == MemberStatus.WITHDRAWN) {
+            throw new ServiceException("403-5", "탈퇴한 계정입니다.");
         }
 
         // Spring Security 인증 객체 생성 ⭐

--- a/src/test/java/com/back/domain/auction/auction/controller/AuctionControllerTest.java
+++ b/src/test/java/com/back/domain/auction/auction/controller/AuctionControllerTest.java
@@ -40,7 +40,7 @@ public class AuctionControllerTest {
 
         ResultActions resultActions = mvc
                 .perform(
-                        delete("/api/auctions/%d".formatted(auctionId))
+                        delete("/api/v1/auctions/%d".formatted(auctionId))
                 )
                 .andDo(print());
 
@@ -63,7 +63,7 @@ public class AuctionControllerTest {
 
         ResultActions resultActions = mvc
                 .perform(
-                        delete("/api/auctions/%d".formatted(auctionId))
+                        delete("/api/v1/auctions/%d".formatted(auctionId))
                 )
                 .andDo(print());
 

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -302,13 +302,13 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("$.resultCode").value("200-1"))
                 .andExpect(jsonPath("$.msg").value("신고 완료 처리되었습니다."));
 
-        assertThat(user1.getReputationEvents()).hasSize(1);
+        assertThat(user1.getTargetEvents()).hasSize(1);
         assertThat(user1.getReputation().getNotifyCount()).isEqualTo(1);
         assertThat(user1.getReputation().getTotalNotifyCount()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("신고 10번 처리 => 신용도 1번 감소")
+    @DisplayName("신고 3번 이상 => 3번 초과 신고 못함")
     @WithUserDetails("user1")
     void t12() throws Exception {
         Member user1 = memberService.findByUsername("user1").get();
@@ -330,46 +330,10 @@ public class MemberControllerTest {
                 .andExpect(handler().handlerType(MemberController.class))
                 .andExpect(handler().methodName("decrease"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value("200-1"))
-                .andExpect(jsonPath("$.msg").value("신고 완료 처리되었습니다."));
-
-        assertThat(user1.getReputationEvents()).hasSize(10);
-        assertThat(user1.getReputation().getNotifyCount()).isEqualTo(10);
-        assertThat(user1.getReputation().getTotalNotifyCount()).isEqualTo(10);
-        assertThat(user1.getReputation().getScore()).isEqualTo(45.0);
+                .andExpect(jsonPath("$.resultCode").value("403-1"))
+                .andExpect(jsonPath("$.msg").value("해당 회원에 대한 신고 횟수를 초과했습니다."));
     }
 
-    @Test
-    @DisplayName("신고 100번 처리 => 계정 1주일 정지")
-    @WithUserDetails("user2")
-    void t13() throws Exception {
-        Member user1 = memberService.findByUsername("user1").get();
-        int userId = user1.getId();
-
-        ResultActions resultActions = null;
-
-        // 10번 반복
-        for (int i = 0; i < 100; i++) {
-            resultActions = mvc
-                    .perform(
-                            patch("/api/v1/members/%d/credit".formatted(userId))
-                    )
-                    .andDo(print());
-        }
-
-        // 마지막 결과만 검증
-        resultActions
-                .andExpect(handler().handlerType(MemberController.class))
-                .andExpect(handler().methodName("decrease"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.resultCode").value("200-1"))
-                .andExpect(jsonPath("$.msg").value("신고 완료 처리되었습니다."));
-
-        assertThat(user1.getReputationEvents()).hasSize(100);
-        assertThat(user1.getReputation().getNotifyCount()).isEqualTo(0);
-        assertThat(user1.getReputation().getTotalNotifyCount()).isEqualTo(100);
-        assertThat(user1.getActive()).isEqualTo(MemberStatus.SUSPENDED);
-    }
 
     @Test
     @DisplayName("정지 계정 리뷰 쓰기 금지")

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -1,6 +1,7 @@
 package com.back.domain.member.member.controller;
 
 import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.enums.MemberStatus;
 import com.back.domain.member.member.service.MemberService;
 import jakarta.servlet.http.Cookie;
 import org.hamcrest.Matchers;
@@ -367,7 +368,7 @@ public class MemberControllerTest {
         assertThat(user1.getReputationEvents()).hasSize(100);
         assertThat(user1.getReputation().getNotifyCount()).isEqualTo(0);
         assertThat(user1.getReputation().getTotalNotifyCount()).isEqualTo(100);
-        assertThat(user1.getActive()).isFalse();
+        assertThat(user1.getActive()).isEqualTo(MemberStatus.SUSPENDED);
     }
 
     @Test


### PR DESCRIPTION
## 🔗 Issue 번호
- close #73

## 🛠 작업 내역
- 회원 영구 정지 구현
- 회원 탈퇴 구현
- 같은 회원 대상 신고 최대 3번만 가능하게끔(일단은)

## 🔄 변경 사항
- 엔티티 여러곳 수정...

## ✨ 새로운 기능
- 회원 영구정지/탈퇴/회원신고 최대3번만

## 📦 작업 유형
- [ ] 신규 기능 추가

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

