### PR TITLE
[Feat] - 중고거래 도메인 api swagger 문서화

### DIFF
--- a/src/main/java/com/back/domain/post/post/controller/PostController.java
+++ b/src/main/java/com/back/domain/post/post/controller/PostController.java
@@ -7,6 +7,11 @@ import com.back.domain.post.post.service.PostService;
 import com.back.global.exception.ServiceException;
 import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 
+@Tag(name = "중고거래", description = "중고거래 게시글 등록, 조회, 수정, 삭제 및 상태 관리 API")
 @RestController
 @RequestMapping("/api/v1/posts")
 @RequiredArgsConstructor
@@ -23,6 +29,14 @@ public class PostController {
     private final PostService postService;
     private final Rq rq;
 
+    @Operation(summary = "중고거래 글 작성", description = "새로운 중고거래 게시글을 작성합니다. **제목(2-50자)**, **내용(10-1000자)** 제한이 있으며, **정지된 회원**은 등록이 차단됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "게시글 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "입력값 유효성 검증 실패 (제목/내용 길이 등)"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (401-1)"),
+            @ApiResponse(responseCode = "403", description = "정지 회원 활동 제한 (403-3)"),
+            @ApiResponse(responseCode = "404", description = "카테고리 정보 없음 (404-2)")
+    })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public RsData<PostIdResponse> create(
             @Valid @ModelAttribute PostCreateRequest req
@@ -37,6 +51,11 @@ public class PostController {
         return new RsData<>("201-1", "게시글 등록이 완료되었습니다", new PostIdResponse(id, "등록 완료"));
     }
 
+    @Operation(summary = "게시글 수정", description = "기존 게시글의 제목, 내용, 가격 등을 수정합니다. 기존 이미지를 유지하거나 새 이미지를 추가할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "본인 글만 수정 가능 (403-1) / 정지 회원 차단 (403-3)")
+    })
     @PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public RsData<PostIdResponse> modify(
             @PathVariable int id,
@@ -52,6 +71,7 @@ public class PostController {
         return new RsData<>("200-1", "수정 성공", new PostIdResponse(id, "수정 완료"));
     }
 
+    @Operation(summary = "게시글 상태 변경", description = "상품의 상태(SALE, RESERVED, SOLD)를 변경합니다.")
     @PatchMapping("/{id}/status")
     public RsData<PostIdResponse> updateStatus(@PathVariable int id, @Valid @RequestBody PostStatusRequest req) {
         Member actor = rq.getActor();
@@ -63,6 +83,7 @@ public class PostController {
         return new RsData<>("200-1", "수정 성공", new PostIdResponse(id, "수정 완료"));
     }
 
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제 처리합니다. (논리적 삭제 적용)")
     @DeleteMapping("/{id}")
     public RsData<PostIdResponse> delete(
             @PathVariable int id
@@ -77,14 +98,17 @@ public class PostController {
         return new RsData<>("200-2", "삭제 성공", new PostIdResponse(id, "삭제 완료"));
     }
 
+    @Operation(summary = "상세 조회", description = "게시글의 상세 정보를 조회합니다. 판매자의 **신용 점수(Score)**가 함께 반환됩니다.")
     @GetMapping("/{id}")
     public RsData<PostDetailResponse> getDetail(@PathVariable int id) {
         return new RsData<>("200-3", "상세 조회 성공", postService.getDetail(id));
     }
 
+    @Operation(summary = "목록 조회", description = "상태별 필터링이 가능한 페이징 목록입니다. 판매자의 **뱃지(Badge)** 정보가 포함됩니다.")
     @GetMapping
     public RsData<PostPageResponse> getList(
             @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable,
+            @Parameter(description = "필터링할 상태 (all, sale, reserved, sold)", example = "sale")
             @RequestParam(required = false) String status
     ) {
         PostPageResponse response = postService.getList(pageable, status);

--- a/src/main/java/com/back/domain/post/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/back/domain/post/post/dto/PostCreateRequest.java
@@ -1,5 +1,6 @@
 package com.back.domain.post.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -7,12 +8,23 @@ import java.util.List;
 
 @Getter @Setter @NoArgsConstructor
 public class PostCreateRequest {
+    @Schema(description = "게시글 제목 (2자 이상 50자 이하)", example = "아이폰 15 프로 128G 블랙")
     @NotBlank(message = "제목은 필수입니다.")
+    @Size(min = 2, max = 50, message = "제목은 2자 이상 50자 이하로 입력해주세요.")
     private String title;
+
+    @Schema(description = "게시글 상세 내용 (10자 이상 1000자 이하)", example = "구매한지 3개월 됐고 상태 좋습니다.")
     @NotBlank(message = "내용은 필수입니다.")
+    @Size(min = 10, max = 1000, message = "내용은 10자 이상 1000자 이하로 입력해주세요.")
     private String content;
-    @Min(0) private int price;
+
+    @Schema(description = "판매 가격 (0원 이상)", example = "950000")
+    @Min(0)
+    private int price;
+
+    @Schema(description = "카테고리 ID", example = "1")
     @NotNull(message = "카테고리를 선택해주세요.")
     private Integer categoryId;
+
     private List<MultipartFile> images;
 }

--- a/src/main/java/com/back/domain/post/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/back/domain/post/post/dto/PostDetailResponse.java
@@ -1,6 +1,8 @@
 package com.back.domain.post.post.dto;
 
 import com.back.domain.post.post.entity.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -13,7 +15,9 @@ public record PostDetailResponse(
     String categoryName,
     int sellerId,
     String sellerNickname,
+    @Schema(description = "판매자 등급 뱃지 (안전/우수/일반/주의)", example = "안전한 판매자")
     String sellerBadge,
+    @Schema(description = "판매자 실제 신용 점수 (상세에서만 노출)", example = "85.5")
     Double sellerScore,
     List<String> imageUrls,
     LocalDateTime createDate,

--- a/src/main/java/com/back/domain/post/post/dto/PostListResponse.java
+++ b/src/main/java/com/back/domain/post/post/dto/PostListResponse.java
@@ -1,6 +1,8 @@
 package com.back.domain.post.post.dto;
 
 import com.back.domain.post.post.entity.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
 public record PostListResponse(
@@ -15,6 +17,7 @@ public record PostListResponse(
     long viewCount,
     int sellerId,
     String sellerNickname,
+    @Schema(description = "판매자 등급 뱃지 (안전/우수/일반/주의)", example = "안전한 판매자")
     String sellerBadge
 ) {
     public PostListResponse(Post post) {

--- a/src/main/java/com/back/domain/post/post/entity/Post.java
+++ b/src/main/java/com/back/domain/post/post/entity/Post.java
@@ -19,8 +19,9 @@ public class Post extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member seller;
 
+    @Column(length = 50, nullable = false)
     private String title;
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
     private int price;
 


### PR DESCRIPTION
## 🔗 Issue 번호
- close #91 

## 🛠 작업 내역
- 제목(2~50자) 및 내용(10~1000자)에 대한 글자 수 제한을 추가 했습니다.
- API Swagger 문서화 했습니다.

## 🔄 변경 사항
- 모든 메서드에 @Operation, @Parameter 등 Swagger 어노테이션 적용 및 @Valid 연동
- 엔티티와 DTO에 각각 @Column 제약 조건 및 @Size 유효성 검사 추가

## ✨ 새로운 기능
-

## 📦 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

