### PR TITLE
[Refactor] Post Fetch Join 적용 refactor

### DIFF
--- a/src/main/java/com/back/domain/post/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/back/domain/post/post/dto/PostDetailResponse.java
@@ -34,8 +34,10 @@ public record PostDetailResponse(
                 post.getCategory().getName(),
                 post.getSeller().getId(),
                 post.getSeller().getNickname(),
-                PostListResponse.calculateBadge(post.getSeller().getReputation().getScore()),
-                post.getSeller().getReputation().getScore(),
+                PostListResponse.calculateBadge(post.getSeller().getReputation() != null ?
+                        post.getSeller().getReputation().getScore() : null),
+                post.getSeller().getReputation() != null ?
+                        post.getSeller().getReputation().getScore() : 0.0,
                 post.getPostImages()
                         .stream()
                         .map(pi -> pi.getImage().getUrl())

--- a/src/main/java/com/back/domain/post/post/dto/PostListResponse.java
+++ b/src/main/java/com/back/domain/post/post/dto/PostListResponse.java
@@ -34,7 +34,8 @@ public record PostListResponse(
                 post.getViewCount(),
                 post.getSeller().getId(),
                 post.getSeller().getNickname(),
-                calculateBadge(post.getSeller().getReputation().getScore())
+                calculateBadge(post.getSeller().getReputation() != null ?
+                        post.getSeller().getReputation().getScore() : null)
         );
     }
 

--- a/src/main/java/com/back/domain/post/post/repository/PostRepository.java
+++ b/src/main/java/com/back/domain/post/post/repository/PostRepository.java
@@ -12,17 +12,33 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Integer> {
 
-    Optional<Post> findByIdAndDeletedFalse(int id);
-
     @Query("SELECT p FROM Post p " +
+            "JOIN FETCH p.seller " +
+            "JOIN FETCH p.category " +
+            "WHERE p.id = :id AND p.deleted = false")
+    Optional<Post> findByIdAndDeletedFalse(@Param("id") int id);
+
+    @Query(value = "SELECT p FROM Post p " +
+            "JOIN FETCH p.seller " +
+            "JOIN FETCH p.category " +
             "WHERE p.deleted = false " +
-            "AND (p.title LIKE %:kw% OR p.content LIKE %:kw%)")
+            "AND (p.title LIKE %:kw% OR p.content LIKE %:kw%)",
+            countQuery = "SELECT count(p) FROM Post p WHERE p.deleted = false AND (p.title LIKE %:kw% OR p.content LIKE %:kw%)")
     Page<Post> search(@Param("kw") String kw, Pageable pageable);
 
-    @Query("SELECT p FROM Post p " +
+    @Query(value = "SELECT p FROM Post p " +
+            "JOIN FETCH p.seller " +
+            "JOIN FETCH p.category " +
             "WHERE p.deleted = false " +
-            "AND (:status IS NULL OR p.status = :status)")
+            "AND (:status IS NULL OR p.status = :status)",
+            countQuery = "SELECT count(p) FROM Post p WHERE p.deleted = false AND (:status IS NULL OR p.status = :status)")
     Page<Post> findPostsByStatus(@Param("status") PostStatus status, Pageable pageable);
+
+    @Query(value = "SELECT p FROM Post p " +
+            "JOIN FETCH p.seller " +
+            "JOIN FETCH p.category " +
+            "WHERE p.deleted = false",
+            countQuery = "SELECT count(p) FROM Post p WHERE p.deleted = false")
     Page<Post> findAllByDeletedFalse(Pageable pageable);
 
     Page<Post> findBySellerIdAndStatus(Integer sellerId, PostStatus status, Pageable pageable);


### PR DESCRIPTION
## 🔗 Issue 번호
- close #112 

## 🛠 작업 내역
- 및 상세 조회 쿼리에 JOIN FETCH
- PostListResponse, PostDetailResponse 생성 시 판매자 평점 정보에 대한 Null 체크 로직 추가

## 🔄 변경 사항
- 기존에 Post를 조회할 때 seller와 category를 개별 쿼리로 가져오던 방식을 단일 조인 쿼리로 통합했습니다.
- Member 객체에 Reputation이 생성되지 않은 경우 발생하던 NullPointerException을 해결했습니다.

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

