### PR TITLE
[Refactor/#130] - Batch_Fetch_Size를 이용한 최적화

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       # JPA 설정
       SPRING_JPA_HIBERNATE_DDL_AUTO: ${JPA_DDL_AUTO:-update}
       SPRING_JPA_SHOW_SQL: ${JPA_SHOW_SQL:-true}
+      SPRING_JPA_PROPERTIES_HIBERNATE_DEFAULT_BATCH_FETCH_SIZE: 100
 
       # 파일 업로드
       FILE_UPLOAD_DIR: /app/uploads

--- a/src/main/java/com/back/domain/post/post/repository/PostRepository.java
+++ b/src/main/java/com/back/domain/post/post/repository/PostRepository.java
@@ -12,32 +12,22 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Integer> {
 
-    @Query("SELECT p FROM Post p " +
-            "JOIN FETCH p.seller " +
-            "JOIN FETCH p.category " +
-            "WHERE p.id = :id AND p.deleted = false")
+    @Query("SELECT p FROM Post p WHERE p.id = :id AND p.deleted = false")
     Optional<Post> findByIdAndDeletedFalse(@Param("id") int id);
 
     @Query(value = "SELECT p FROM Post p " +
-            "JOIN FETCH p.seller " +
-            "JOIN FETCH p.category " +
             "WHERE p.deleted = false " +
             "AND (p.title LIKE %:kw% OR p.content LIKE %:kw%)",
             countQuery = "SELECT count(p) FROM Post p WHERE p.deleted = false AND (p.title LIKE %:kw% OR p.content LIKE %:kw%)")
     Page<Post> search(@Param("kw") String kw, Pageable pageable);
 
     @Query(value = "SELECT p FROM Post p " +
-            "JOIN FETCH p.seller " +
-            "JOIN FETCH p.category " +
             "WHERE p.deleted = false " +
             "AND (:status IS NULL OR p.status = :status)",
             countQuery = "SELECT count(p) FROM Post p WHERE p.deleted = false AND (:status IS NULL OR p.status = :status)")
     Page<Post> findPostsByStatus(@Param("status") PostStatus status, Pageable pageable);
 
-    @Query(value = "SELECT p FROM Post p " +
-            "JOIN FETCH p.seller " +
-            "JOIN FETCH p.category " +
-            "WHERE p.deleted = false",
+    @Query(value = "SELECT p FROM Post p WHERE p.deleted = false",
             countQuery = "SELECT count(p) FROM Post p WHERE p.deleted = false")
     Page<Post> findAllByDeletedFalse(Pageable pageable);
 


### PR DESCRIPTION
## 🔗 Issue 번호
- close #130 

## 🛠 작업 내역
- 기존의 join fetch 방식에서 발생하던 메모리 부하 및 페이징 성능 저하 문제를 해결하기 위해 전역 배치 조회 설정 도입

## 🔄 변경 사항
- hibernate.default_batch_fetch_size: 100 설정 추가
- fetch join 구문 삭제.
## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

